### PR TITLE
Remove number pad and add bill input field

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -8,26 +8,24 @@ test('renders pricing calculator title', () => {
   expect(title).toBeTruthy();
 });
 
-test('renders keypad enter button', () => {
+test('renders pay amount label', () => {
   render(<App />);
-  const enter = screen.getByText('Enter');
-  expect(enter).toBeTruthy();
+  const label = screen.getByText('Pay Amount');
+  expect(label).toBeTruthy();
 });
 
-test('updates input when keypad button pressed', () => {
+test('updates input when typed', () => {
   render(<App />);
-  const button = screen.getByText('1');
-  fireEvent.press(button);
-  const input = screen.getByTestId('input-field');
+  const input = screen.getByTestId('pay-input');
+  fireEvent.changeText(input, '1');
   expect(input.props.value).toBe('1');
 });
 
-test('shows billing information after pressing enter', () => {
+test('shows billing information after submitting', () => {
   render(<App />);
-  const one = screen.getByText('1');
-  fireEvent.press(one);
-  const enter = screen.getByText('Enter');
-  fireEvent.press(enter);
-  const bill = screen.getByText(/Bill Amount/i);
-  expect(bill).toBeTruthy();
+  const input = screen.getByTestId('pay-input');
+  fireEvent.changeText(input, '1');
+  fireEvent(input, 'submitEditing');
+  const display = screen.getByText(/High Billing Range/i);
+  expect(display).toBeTruthy();
 });

--- a/app/components/BillingDisplay.js
+++ b/app/components/BillingDisplay.js
@@ -6,7 +6,7 @@ export default function BillingDisplay({ data }) {
   if (!data) {
     return null;
   }
-  const billAmount = data.highBilling;
+  const billAmount = data.billAmount ?? data.highBilling;
   const profitAmount = billAmount - data.payAmount;
   const profitMargin = billAmount === 0 ? 0 : (profitAmount / billAmount) * 100;
 

--- a/app/components/InputSection.js
+++ b/app/components/InputSection.js
@@ -1,51 +1,48 @@
 import React, { useState } from 'react';
-import { View, TextInput, StyleSheet } from 'react-native';
-import KeypadButton from './KeypadButton';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
 import BillingDisplay from './BillingDisplay';
 import { getBillingRange } from '../utils/billing';
 import theme from '../theme';
 
 export default function InputSection() {
-  const [value, setValue] = useState('');
+  const [payValue, setPayValue] = useState('');
+  const [billValue, setBillValue] = useState('');
   const [billingData, setBillingData] = useState(null);
 
-  const handlePress = (key) => {
-    if (key === 'Enter') {
-      const num = parseFloat(value);
-      const result = getBillingRange(num);
-      setBillingData(result);
-      setValue('');
+  const handleSubmit = () => {
+    const payNum = parseFloat(payValue);
+    if (isNaN(payNum)) {
       return;
     }
-    setValue((prev) => prev + key);
+    const billNum = parseFloat(billValue);
+    const result = getBillingRange(payNum);
+    setBillingData({ ...result, billAmount: isNaN(billNum) ? 0 : billNum });
   };
-
-  const rows = [
-    ['1', '2', '3'],
-    ['4', '5', '6'],
-    ['7', '8', '9'],
-    ['0', 'Enter'],
-  ];
 
   return (
     <View style={styles.container}>
+      <Text style={styles.label}>Pay Amount</Text>
       <TextInput
         style={styles.input}
-        placeholder="Enter value"
+        placeholder="Enter pay amount"
         placeholderTextColor={theme.accent}
-        value={value}
-        onChangeText={setValue}
-        testID="input-field"
+        value={payValue}
+        onChangeText={setPayValue}
+        onSubmitEditing={handleSubmit}
+        keyboardType="numeric"
+        testID="pay-input"
       />
-      <View style={styles.keypad}>
-        {rows.map((row, rowIndex) => (
-          <View key={rowIndex} style={styles.row}>
-            {row.map((label) => (
-              <KeypadButton key={label} label={label} onPress={handlePress} />
-            ))}
-          </View>
-        ))}
-      </View>
+      <Text style={styles.label}>Bill Amount</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Enter bill amount"
+        placeholderTextColor={theme.accent}
+        value={billValue}
+        onChangeText={setBillValue}
+        onSubmitEditing={handleSubmit}
+        keyboardType="numeric"
+        testID="bill-input"
+      />
       {billingData && <BillingDisplay data={billingData} />}
     </View>
   );
@@ -66,12 +63,9 @@ const styles = StyleSheet.create({
     color: theme.text,
     fontFamily: theme.font,
   },
-  keypad: {
-    justifyContent: 'center',
-  },
-  row: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 5,
+  label: {
+    color: theme.text,
+    marginBottom: 4,
+    fontFamily: theme.font,
   },
 });


### PR DESCRIPTION
## Summary
- simplify input section with normal text inputs
- remove keypad references
- add optional Bill Amount entry and display
- update billing display to use bill amount if provided
- refresh tests for updated UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ce816b368832981cd18225b877446