### PR TITLE
Always display billing info placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,5 @@ The screen will show:
 - **High Billing Range**
 - **Low Billing Range**
 
-These values update each time you enter a new pay amount.
+These values are always visible. Before entering data they show **0.00** as a
+placeholder and update each time you submit a new pay amount.

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -21,11 +21,8 @@ test('updates input when typed', () => {
   expect(input.props.value).toBe('1');
 });
 
-test('shows billing information after submitting', () => {
+test('shows billing information on initial render', () => {
   render(<App />);
-  const input = screen.getByTestId('pay-input');
-  fireEvent.changeText(input, '1');
-  fireEvent(input, 'submitEditing');
   const display = screen.getByText(/High Billing Range/i);
   expect(display).toBeTruthy();
 });

--- a/app/components/BillingDisplay.js
+++ b/app/components/BillingDisplay.js
@@ -3,11 +3,11 @@ import { View, Text, StyleSheet } from 'react-native';
 import theme from '../theme';
 
 export default function BillingDisplay({ data }) {
-  if (!data) {
-    return null;
-  }
-  const billAmount = data.billAmount ?? data.highBilling;
-  const profitAmount = billAmount - data.payAmount;
+  const billAmount = data?.billAmount ?? data?.highBilling ?? 0;
+  const payAmount = data?.payAmount ?? 0;
+  const highBilling = data?.highBilling ?? 0;
+  const lowBilling = data?.lowBilling ?? 0;
+  const profitAmount = billAmount - payAmount;
   const profitMargin = billAmount === 0 ? 0 : (profitAmount / billAmount) * 100;
 
   const format = (n) => n.toFixed(2);
@@ -15,11 +15,11 @@ export default function BillingDisplay({ data }) {
   return (
     <View style={styles.container}>
       <Text style={styles.row}>Bill Amount: {format(billAmount)}</Text>
-      <Text style={styles.row}>Pay Amount: {format(data.payAmount)}</Text>
+      <Text style={styles.row}>Pay Amount: {format(payAmount)}</Text>
       <Text style={styles.row}>Profit Amount: {format(profitAmount)}</Text>
       <Text style={styles.row}>Profit Margin: {format(profitMargin)}%</Text>
-      <Text style={styles.row}>High Billing Range: {format(data.highBilling)}</Text>
-      <Text style={styles.row}>Low Billing Range: {format(data.lowBilling)}</Text>
+      <Text style={styles.row}>High Billing Range: {format(highBilling)}</Text>
+      <Text style={styles.row}>Low Billing Range: {format(lowBilling)}</Text>
     </View>
   );
 }

--- a/app/components/InputSection.js
+++ b/app/components/InputSection.js
@@ -7,7 +7,12 @@ import theme from '../theme';
 export default function InputSection() {
   const [payValue, setPayValue] = useState('');
   const [billValue, setBillValue] = useState('');
-  const [billingData, setBillingData] = useState(null);
+  const [billingData, setBillingData] = useState({
+    payAmount: 0,
+    billAmount: 0,
+    highBilling: 0,
+    lowBilling: 0,
+  });
 
   const handleSubmit = () => {
     const payNum = parseFloat(payValue);
@@ -16,7 +21,10 @@ export default function InputSection() {
     }
     const billNum = parseFloat(billValue);
     const result = getBillingRange(payNum);
-    setBillingData({ ...result, billAmount: isNaN(billNum) ? 0 : billNum });
+    setBillingData({
+      ...result,
+      billAmount: isNaN(billNum) ? 0 : billNum,
+    });
   };
 
   return (
@@ -43,7 +51,7 @@ export default function InputSection() {
         keyboardType="numeric"
         testID="bill-input"
       />
-      {billingData && <BillingDisplay data={billingData} />}
+      <BillingDisplay data={billingData} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- render `BillingDisplay` at all times with 0.00 placeholders
- compute display values safely when no data is entered
- update README instructions for placeholders
- update unit test to assert billing info is visible on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ceb6a69fc8329a972d374d725655f