### PR TITLE
Display markup percentages

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -26,3 +26,12 @@ test('shows billing information on initial render', () => {
   const display = screen.getByText(/High Billing Range/i);
   expect(display).toBeTruthy();
 });
+
+test('displays markup percentages after entering pay amount', () => {
+  render(<App />);
+  const input = screen.getByTestId('pay-input');
+  fireEvent.changeText(input, '100');
+  fireEvent(input, 'submitEditing');
+  const markup = screen.getByText('High: 122.50%, Low: 94.75%');
+  expect(markup).toBeTruthy();
+});

--- a/app/components/BillingDisplay.js
+++ b/app/components/BillingDisplay.js
@@ -7,6 +7,8 @@ export default function BillingDisplay({ data }) {
   const payAmount = data?.payAmount ?? 0;
   const highBilling = data?.highBilling ?? 0;
   const lowBilling = data?.lowBilling ?? 0;
+  const highPercentage = data?.highPercentage ?? 0;
+  const lowPercentage = data?.lowPercentage ?? 0;
   const profitAmount = billAmount - payAmount;
   const profitMargin = billAmount === 0 ? 0 : (profitAmount / billAmount) * 100;
 
@@ -36,6 +38,14 @@ export default function BillingDisplay({ data }) {
         <Text style={styles.label}>Low Billing Range</Text>
         <View style={styles.box}>
           <Text style={styles.boxText}>{format(lowBilling)}</Text>
+        </View>
+      </View>
+      <View style={styles.item}>
+        <Text style={styles.label}>Markup% Used</Text>
+        <View style={styles.box}>
+          <Text style={styles.boxText}>
+            {`High: ${format(highPercentage * 100)}%, Low: ${format(lowPercentage * 100)}%`}
+          </Text>
         </View>
       </View>
     </View>

--- a/app/components/InputSection.js
+++ b/app/components/InputSection.js
@@ -12,6 +12,8 @@ export default function InputSection() {
     billAmount: 0,
     highBilling: 0,
     lowBilling: 0,
+    highPercentage: 0,
+    lowPercentage: 0,
   });
 
   const handleSubmit = () => {


### PR DESCRIPTION
## Summary
- show high and low markup percentages
- track markup percentages in component state
- test markup percentage rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68936cee326883299e878282fed15cf3