### PR TITLE
feat: make advanced settings scrollable

### DIFF
--- a/app/components/AdvancedSettings.js
+++ b/app/components/AdvancedSettings.js
@@ -16,8 +16,8 @@ export default function AdvancedSettings() {
     });
   };
 
-  const renderTable = (title, data, setData) => (
-    <View style={styles.tableContainer}>
+  const renderTable = (title, data, setData, style) => (
+    <View style={[styles.tableContainer, style]}>
       <Text style={styles.header}>{title}</Text>
       {data.map(([price, pct], idx) => (
         <View key={idx} style={styles.row}>
@@ -40,8 +40,10 @@ export default function AdvancedSettings() {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      {renderTable('High Range', highRange, setHighRange)}
-      {renderTable('Low Range', lowRange, setLowRange)}
+      <View style={styles.tablesWrapper}>
+        {renderTable('High Range', highRange, setHighRange, { marginRight: 10 })}
+        {renderTable('Low Range', lowRange, setLowRange)}
+      </View>
       <View style={styles.buttonRow}>
         <Button title="Save" onPress={saveTables} />
         <Button title="Reset" onPress={resetTables} />
@@ -56,8 +58,14 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: 10,
+    flexGrow: 1,
+  },
+  tablesWrapper: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   tableContainer: {
+    flex: 1,
     marginBottom: 20,
   },
   header: {


### PR DESCRIPTION
## Summary
- allow advanced settings to scroll vertically
- show high and low markup tables side by side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893ab48c9a483299da5d9f8b5eb42ff