### PR TITLE
feat: enable mouse wheel scrolling on advanced page

### DIFF
--- a/__tests__/AdvancedSettings.test.js
+++ b/__tests__/AdvancedSettings.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import AdvancedSettings from '../app/components/AdvancedSettings';
+import { MarkupProvider } from '../app/context/MarkupContext';
+
+test('advanced settings scroll supports wheel', () => {
+  const { getByTestId } = render(
+    <MarkupProvider>
+      <AdvancedSettings />
+    </MarkupProvider>
+  );
+  const scroll = getByTestId('advanced-scroll');
+  expect(typeof scroll.props.onWheel).toBe('function');
+});

--- a/app/components/AdvancedSettings.js
+++ b/app/components/AdvancedSettings.js
@@ -1,10 +1,12 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import { View, Text, TextInput, ScrollView, StyleSheet, Button } from 'react-native';
 import MarkupContext from '../context/MarkupContext';
 import theme from '../theme';
 
 export default function AdvancedSettings() {
   const { highRange, lowRange, setHighRange, setLowRange, resetTables, saveTables } = useContext(MarkupContext);
+  const scrollRef = useRef(null);
+  const offsetRef = useRef(0);
 
   const updateRow = (setTable, index, field, value) => {
     const num = parseFloat(value);
@@ -38,8 +40,29 @@ export default function AdvancedSettings() {
     </View>
   );
 
+  const handleScroll = e => {
+    offsetRef.current = e.nativeEvent.contentOffset.y;
+  };
+
+  const handleWheel = e => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({
+        y: offsetRef.current + e.nativeEvent.deltaY,
+        animated: false,
+      });
+    }
+  };
+
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <ScrollView
+      testID="advanced-scroll"
+      ref={scrollRef}
+      onScroll={handleScroll}
+      scrollEventThrottle={16}
+      onWheel={handleWheel}
+      style={styles.container}
+      contentContainerStyle={styles.content}
+    >
       <View style={styles.tablesWrapper}>
         {renderTable('High Range', highRange, setHighRange, { marginRight: 10 })}
         {renderTable('Low Range', lowRange, setLowRange)}


### PR DESCRIPTION
## Summary
- enable wheel-based scrolling on the advanced settings screen
- add test to ensure wheel handler exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893ad2ff2148329b3a7869f7bb49ef4