### PR TITLE
fix: wheel scroll event support in advanced settings inputs

### DIFF
--- a/__tests__/AdvancedSettings.test.js
+++ b/__tests__/AdvancedSettings.test.js
@@ -4,11 +4,13 @@ import AdvancedSettings from '../app/components/AdvancedSettings';
 import { MarkupProvider } from '../app/context/MarkupContext';
 
 test('advanced settings scroll supports wheel', () => {
-  const { getByTestId } = render(
+  const { getByTestId, getAllByDisplayValue } = render(
     <MarkupProvider>
       <AdvancedSettings />
     </MarkupProvider>
   );
   const scroll = getByTestId('advanced-scroll');
   expect(typeof scroll.props.onWheel).toBe('function');
+  const inputs = getAllByDisplayValue('0');
+  expect(inputs.some(input => typeof input.props.onWheel === 'function')).toBe(true);
 });

--- a/app/components/AdvancedSettings.js
+++ b/app/components/AdvancedSettings.js
@@ -18,28 +18,6 @@ export default function AdvancedSettings() {
     });
   };
 
-  const renderTable = (title, data, setData, style) => (
-    <View style={[styles.tableContainer, style]}>
-      <Text style={styles.header}>{title}</Text>
-      {data.map(([price, pct], idx) => (
-        <View key={idx} style={styles.row}>
-          <TextInput
-            style={styles.cell}
-            keyboardType="numeric"
-            value={String(price)}
-            onChangeText={text => updateRow(setData, idx, 0, text)}
-          />
-          <TextInput
-            style={styles.cell}
-            keyboardType="numeric"
-            value={String(pct)}
-            onChangeText={text => updateRow(setData, idx, 1, text)}
-          />
-        </View>
-      ))}
-    </View>
-  );
-
   const handleScroll = e => {
     offsetRef.current = e.nativeEvent.contentOffset.y;
   };
@@ -58,6 +36,30 @@ export default function AdvancedSettings() {
       });
     }
   };
+
+  const renderTable = (title, data, setData, style) => (
+    <View style={[styles.tableContainer, style]}>
+      <Text style={styles.header}>{title}</Text>
+      {data.map(([price, pct], idx) => (
+        <View key={idx} style={styles.row}>
+          <TextInput
+            style={styles.cell}
+            keyboardType="numeric"
+            value={String(price)}
+            onChangeText={text => updateRow(setData, idx, 0, text)}
+            onWheel={handleWheel}
+          />
+          <TextInput
+            style={styles.cell}
+            keyboardType="numeric"
+            value={String(pct)}
+            onChangeText={text => updateRow(setData, idx, 1, text)}
+            onWheel={handleWheel}
+          />
+        </View>
+      ))}
+    </View>
+  );
 
   return (
     <ScrollView


### PR DESCRIPTION
## Summary
- forward mouse wheel events from advanced settings inputs to the scroll container
- test that text inputs hook wheel events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893b76a6ed88329841d8485a6eedabe