### PR TITLE
docs: add cross-platform build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ npm test
 
 The included test verifies that the main screen renders the "Pricing Calculator" title.
 
+## Building Windows binaries on Linux
+
+Electron Builder can create Windows artifacts from Linux hosts, but it requires Wine, Mono, and a virtual display.
+
+1. **Install Wine and Mono with 32‑bit support**
+   ```bash
+   sudo dpkg --add-architecture i386 && sudo apt-get update
+   sudo apt-get install -y wine64 wine32 libwine libwine:i386 mono-devel
+   wine --version
+   mono --version
+   ```
+2. **Provide a virtual X server** – necessary when running in headless environments.
+   ```bash
+   sudo apt-get install -y xvfb
+   npm run electron:build:linux
+   ```
+   The `electron:build:linux` script wraps `electron-builder` with `xvfb-run`.
+3. **Alternative: build on Windows** – install Node.js and run:
+   ```bash
+   npm install
+   npm run electron:build
+   ```
+
 ## Project Structure
 - `index.js` – default entry file importing `app/index.js`
 - `app/App.js` – React Native component rendered on screen

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "react-native start",
     "test": "jest",
     "electron:start": "electron .",
-    "electron:build": "electron-builder --win"
+    "electron:build": "electron-builder --win",
+    "electron:build:linux": "xvfb-run -a electron-builder --win"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- add a script for Linux cross-building that wraps electron-builder with `xvfb-run`
- document Wine/Mono installation and alternative build options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68940b4b6d648329948735d748a41868