### PR TITLE
Add environment test for missing wine

### DIFF
--- a/__tests__/wine.test.js
+++ b/__tests__/wine.test.js
@@ -1,0 +1,11 @@
+const { exec } = require('child_process');
+
+test('wine command is unavailable or fails to execute', done => {
+  exec('wine --version', (error, stdout, stderr) => {
+    console.log('wine stdout:', stdout.trim());
+    console.log('wine stderr:', stderr.trim());
+    expect(error).not.toBeNull();
+    expect(stderr).toMatch(/(not found|Exec format error)/);
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test that executes `wine --version` and logs output to highlight missing Wine dependency

## Testing
- `npm test`
- `npm run electron:build:linux` *(fails: `xvfb-run: not found`)*


------
https://chatgpt.com/codex/tasks/task_b_68940d3535f8832994a1d2b5dd0ba784