### PR TITLE
fix: add import map for react native web

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Pricing Calculator</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@18.2.0",
+          "react-dom": "https://esm.sh/react-dom@18.2.0",
+          "react-native": "https://esm.sh/react-native-web@0.19.9"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add import map in `index.html` to resolve react-native using react-native-web via CDN

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6894bc6b99908329aa74bcf34dda4b52