### PR TITLE
Remove JSON import assertion for compatibility

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,6 @@
 import { AppRegistry } from 'react-native';
 import App from './App.js';
-import appConfig from './app.json' assert { type: 'json' };
+import appConfig from './app.json';
 
 const appName = appConfig.name;
 


### PR DESCRIPTION
## Summary
- Remove import assertion syntax from `app/index.js` so React Native/Metro can parse the file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6894c8c076cc8329ad31bdb64ffe36c2