### PR TITLE
feat: fetch app name on bootstrap

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,13 +1,25 @@
 import { AppRegistry } from 'react-native';
 import App from './App.js';
-import appConfig from './app.json';
 
-const appName = appConfig.name;
+async function bootstrap() {
+  let appName = 'pricingcalculatorapp';
+  try {
+    const response = await fetch('./app.json');
+    const { name } = await response.json();
+    if (name) {
+      appName = name;
+    }
+  } catch (error) {
+    console.error('Failed to load app configuration', error);
+  }
 
-AppRegistry.registerComponent(appName, () => App);
+  AppRegistry.registerComponent(appName, () => App);
 
-if (typeof document !== 'undefined') {
-  AppRegistry.runApplication(appName, {
-    rootTag: document.getElementById('root'),
-  });
+  if (typeof document !== 'undefined') {
+    AppRegistry.runApplication(appName, {
+      rootTag: document.getElementById('root'),
+    });
+  }
 }
+
+bootstrap();


### PR DESCRIPTION
## Summary
- fetch app configuration asynchronously instead of static import
- register app only after resolving its name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6894e20cbaf88329a8544d7cc58dfe55