### PR TITLE
docs: update readme with browser run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,42 @@
-# Pricing Calculator React Native App
+# Pricing Calculator
 
-This repository contains a minimal React Native project that can be extended with [react-native-windows](https://microsoft.github.io/react-native-windows/) to run on Windows. It serves as a simple starting point for building out the GUI of a pricing calculator.
+This is a minimal React application that calculates billing and profit information.
 
 ## Getting Started
 
-The app can be run on Windows using the React Native Windows extension. Below is a step-by-step guide for setting up the project, running it, and executing the automated tests.
-
 ### Prerequisites
 - [Node.js](https://nodejs.org/) 18 or later
-- [Yarn](https://classic.yarnpkg.com/en/docs/install/) (optional, `npm` works too)
-- A Windows development machine with Visual Studio 2022 or later for building the Windows project. Ensure `vswhere.exe` is available in your `PATH`.
 
-### Setup
-1. **Clone and install dependencies**
-   ```bash
-   git clone <repo-url>
-   cd PricingCalc
-   # Run all following commands from this directory
-   npm install
-   ```
-2. **Generate Windows project files** – this will create a `windows/` directory containing the native solution:
-   ```bash
-   npx react-native-windows-init --overwrite
-   ```
-3. **Install Windows dependencies** – run the following script from an *elevated* PowerShell prompt:
-   ```powershell
-   node_modules/react-native-windows/scripts/rnw-dependencies.ps1
-   ```
-   Make sure Visual Studio 2022 or later is installed and `vswhere.exe` can be found on your `PATH`.
-4. **Start the Metro bundler** – keep this running in its own terminal window:
-   ```bash
-   npm start
-   ```
-   This uses the root `index.js` file which simply imports `app/index.js`.
-5. **Build and run the app** in a separate terminal:
-   ```bash
-   npx react-native run-windows
-   ```
+### Install dependencies
+```bash
+npm install
+```
 
-After compilation completes, a window should open displaying the "Pricing Calculator" heading.
+### Run the app in your browser
+```bash
+npm start
+```
+The start script uses [`serve`](https://www.npmjs.com/package/serve) to host the project. After the command runs, open [http://localhost:3000](http://localhost:3000) in a web browser to view the Pricing Calculator.
 
-### Running Tests
-
-Automated tests are written using [Jest](https://jestjs.io/) and `@testing-library/react-native`. Use the following command to execute the test suite:
-
+### Running tests
 ```bash
 npm test
 ```
 
-The included test verifies that the main screen renders the "Pricing Calculator" title.
-
 ## Project Structure
-- `index.js` – default entry file importing `app/index.js`
-- `app/App.js` – React Native component rendered on screen
-- `app/index.js` – entry point that registers the app
-- `app/app.json` – application metadata
-- `package.json` – project configuration and dependencies
-
-Feel free to modify `App.js` to begin building your UI.
+- `index.html` – HTML entry point
+- `index.js` – imports and runs `app/index.js`
+- `app/App.js` – main React component
+- `app/index.js` – creates the React root and renders `App`
+- `package.json` – project configuration
 
 ## Billing and Profit Display
 
-Enter an amount using the keypad and press **Enter** to calculate billing ranges.
-The screen will show:
+Enter an amount using the keypad and press **Enter** to calculate billing ranges. The screen will show:
 
- - **Profit Amount**
- - **Profit Margin**
- - **High Billing Range**
- - **Low Billing Range**
+- **Profit Amount**
+- **Profit Margin**
+- **High Billing Range**
+- **Low Billing Range**
 
-These values are always visible. Before entering data they show **0.00** as a
-placeholder and update each time you submit a new pay amount.
+These values are always visible. Before entering data they show **0.00** as a placeholder and update each time you submit a new pay amount.


### PR DESCRIPTION
## Summary
- refresh README to describe running Pricing Calculator in a web browser
- document installing dependencies, starting the server, and running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a5ce4d9b083299c8c503e8dd4c044