### PR TITLE
Add Babel runtime for JSX

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,13 @@
     {
       "imports": {
         "react": "https://esm.sh/react@18",
-        "react-dom/client": "https://esm.sh/react-dom@18/client"
+        "react-dom/client": "https://esm.sh/react-dom@18/client",
+        "react/jsx-runtime": "https://esm.sh/react@18/jsx-runtime",
+        "react/jsx-dev-runtime": "https://esm.sh/react@18/jsx-dev-runtime"
       }
     }
   </script>
-  <script type="module" src="./app/index.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-type="module" data-presets="env,react" src="./app/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable in-browser Babel transform and import map entries for JSX runtime to fix parsing error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a6090b32883298afb43860e15aa0b