### PR TITLE
fix: remove env preset to support ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@
     }
   </script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script type="text/babel" data-type="module" data-presets="env,react" src="./app/index.js"></script>
+  <script type="text/babel" data-type="module" data-presets="react" src="./app/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Babel without env preset to keep ES module syntax

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a64bd2b4083298a2d0a768bd13d36