### PR TITLE
fix: ensure browser module imports include extension

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import InputSection from './components/InputSection';
-import theme from './theme';
+import InputSection from './components/InputSection.js';
+import theme from './theme.js';
 
 export default function App() {
   return (

--- a/app/components/BillingDisplay.js
+++ b/app/components/BillingDisplay.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import theme from '../theme';
+import theme from '../theme.js';
 
 export default function BillingDisplay({ data }) {
   const billAmount = data?.billAmount ?? data?.highBilling ?? 0;

--- a/app/components/InputSection.js
+++ b/app/components/InputSection.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import BillingDisplay from './BillingDisplay';
-import { getBillingRange } from '../utils/billing';
-import theme from '../theme';
+import BillingDisplay from './BillingDisplay.js';
+import { getBillingRange } from '../utils/billing.js';
+import theme from '../theme.js';
 
 export default function InputSection() {
   const [payValue, setPayValue] = useState('');

--- a/app/components/KeypadButton.js
+++ b/app/components/KeypadButton.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import theme from '../theme';
+import theme from '../theme.js';
 
 export default function KeypadButton({ label, onPress }) {
   const [pressed, setPressed] = useState(false);

--- a/app/components/PercentageTable.js
+++ b/app/components/PercentageTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import theme from '../theme';
+import theme from '../theme.js';
 
 export default function PercentageTable({ title }) {
   const values = [1, 5];

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App';
+import App from './App.js';
 
 const rootElement = document.getElementById('root');
 console.log('Bootstrapping React application. Root element:', rootElement);


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions to relative imports so the server returns JavaScript with the correct MIME type

## Testing
- `npm test`
- `curl -I http://localhost:3000/app/index.js`


------
https://chatgpt.com/codex/tasks/task_b_689a6ad1a7bc8329b967e2a414dff4df