### PR TITLE
fix: load app entry with absolute path

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     }
   </script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script type="text/babel" data-type="module" data-presets="react" src="./app/index.js"></script>
+  <!-- Use an absolute path so the script loads correctly on nested routes -->
+  <script type="text/babel" data-type="module" data-presets="react" src="/app/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the browser requests the app entry script from an absolute path
- prevent incorrect MIME type errors when visiting nested routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a6c05ad3c8329a0d42fa8060a319e