### PR TITLE
Remove JSX usage to avoid parsing errors

### DIFF
--- a/app/BillingDisplay.js
+++ b/app/BillingDisplay.js
@@ -13,39 +13,67 @@ export default function BillingDisplay({ data }) {
 
   const format = (n) => n.toFixed(2);
 
-  return (
-    <View style={styles.container}>
-      <View style={styles.item}>
-        <Text style={styles.label}>Profit Amount</Text>
-        <View style={styles.box}>
-          <Text style={styles.boxText}>{format(profitAmount)}</Text>
-        </View>
-      </View>
-      <View style={styles.item}>
-        <Text style={styles.label}>Profit Margin</Text>
-        <View style={styles.box}>
-          <Text style={styles.boxText}>{format(profitMargin)}%</Text>
-        </View>
-      </View>
-      <View style={styles.item}>
-        <Text style={styles.label}>High Billing Range</Text>
-        <View style={styles.box}>
-          <Text style={styles.boxText}>{format(highBilling)}</Text>
-        </View>
-      </View>
-      <View style={styles.item}>
-        <Text style={styles.label}>Low Billing Range</Text>
-        <View style={styles.box}>
-          <Text style={styles.boxText}>{format(lowBilling)}</Text>
-        </View>
-      </View>
-      <View style={styles.item}>
-        <Text style={styles.label}>Markup% Used</Text>
-        <View style={styles.box}>
-          <Text style={styles.boxText}>{format(markupUsed)}%</Text>
-        </View>
-      </View>
-    </View>
+  return React.createElement(
+    View,
+    { style: styles.container },
+    React.createElement(
+      View,
+      { style: styles.item },
+      React.createElement(Text, { style: styles.label }, 'Profit Amount'),
+      React.createElement(
+        View,
+        { style: styles.box },
+        React.createElement(Text, { style: styles.boxText }, format(profitAmount)),
+      ),
+    ),
+    React.createElement(
+      View,
+      { style: styles.item },
+      React.createElement(Text, { style: styles.label }, 'Profit Margin'),
+      React.createElement(
+        View,
+        { style: styles.box },
+        React.createElement(
+          Text,
+          { style: styles.boxText },
+          `${format(profitMargin)}%`,
+        ),
+      ),
+    ),
+    React.createElement(
+      View,
+      { style: styles.item },
+      React.createElement(Text, { style: styles.label }, 'High Billing Range'),
+      React.createElement(
+        View,
+        { style: styles.box },
+        React.createElement(Text, { style: styles.boxText }, format(highBilling)),
+      ),
+    ),
+    React.createElement(
+      View,
+      { style: styles.item },
+      React.createElement(Text, { style: styles.label }, 'Low Billing Range'),
+      React.createElement(
+        View,
+        { style: styles.box },
+        React.createElement(Text, { style: styles.boxText }, format(lowBilling)),
+      ),
+    ),
+    React.createElement(
+      View,
+      { style: styles.item },
+      React.createElement(Text, { style: styles.label }, 'Markup% Used'),
+      React.createElement(
+        View,
+        { style: styles.box },
+        React.createElement(
+          Text,
+          { style: styles.boxText },
+          `${format(markupUsed)}%`,
+        ),
+      ),
+    ),
   );
 }
 

--- a/app/InputSection.js
+++ b/app/InputSection.js
@@ -27,30 +27,30 @@ export default function InputSection() {
     });
   }, [payValue, billValue]);
 
-  return (
-    <View style={styles.container}>
-      <Text style={styles.label}>Pay Amount</Text>
-      <TextInput
-        style={styles.input}
-        placeholder="Enter pay amount"
-        placeholderTextColor={theme.accent}
-        value={payValue}
-        onChangeText={setPayValue}
-        keyboardType="numeric"
-        testID="pay-input"
-      />
-      <Text style={styles.label}>Bill Amount</Text>
-      <TextInput
-        style={styles.input}
-        placeholder="Enter bill amount"
-        placeholderTextColor={theme.accent}
-        value={billValue}
-        onChangeText={setBillValue}
-        keyboardType="numeric"
-        testID="bill-input"
-      />
-      <BillingDisplay data={billingData} />
-    </View>
+  return React.createElement(
+    View,
+    { style: styles.container },
+    React.createElement(Text, { style: styles.label }, 'Pay Amount'),
+    React.createElement(TextInput, {
+      style: styles.input,
+      placeholder: 'Enter pay amount',
+      placeholderTextColor: theme.accent,
+      value: payValue,
+      onChangeText: setPayValue,
+      keyboardType: 'numeric',
+      testID: 'pay-input',
+    }),
+    React.createElement(Text, { style: styles.label }, 'Bill Amount'),
+    React.createElement(TextInput, {
+      style: styles.input,
+      placeholder: 'Enter bill amount',
+      placeholderTextColor: theme.accent,
+      value: billValue,
+      onChangeText: setBillValue,
+      keyboardType: 'numeric',
+      testID: 'bill-input',
+    }),
+    React.createElement(BillingDisplay, { data: billingData }),
   );
 }
 


### PR DESCRIPTION
## Summary
- Refactor InputSection and BillingDisplay components to use `React.createElement` instead of JSX, matching rest of app and preventing browser syntax errors.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b7b6b6cd08329bb63e4b70de20fff