### PR TITLE
Show high and low markup percentages

### DIFF
--- a/app/BillingDisplay.js
+++ b/app/BillingDisplay.js
@@ -9,7 +9,8 @@ export default function BillingDisplay({ data }) {
   const lowBilling = data?.lowBilling ?? 0;
   const profitAmount = billAmount - payAmount;
   const profitMargin = billAmount === 0 ? 0 : (profitAmount / billAmount) * 100;
-  const markupUsed = payAmount === 0 ? 0 : ((billAmount / payAmount) - 1) * 100;
+  const highMarkup = (data?.highPercentage ?? 0) * 100;
+  const lowMarkup = (data?.lowPercentage ?? 0) * 100;
 
   const format = (n) => n.toFixed(2);
 
@@ -70,7 +71,12 @@ export default function BillingDisplay({ data }) {
         React.createElement(
           Text,
           { style: styles.boxText },
-          `${format(markupUsed)}%`,
+          `High: ${format(highMarkup)}%`,
+        ),
+        React.createElement(
+          Text,
+          { style: styles.boxText },
+          `Low: ${format(lowMarkup)}%`,
         ),
       ),
     ),

--- a/app/InputSection.js
+++ b/app/InputSection.js
@@ -12,6 +12,8 @@ export default function InputSection() {
     billAmount: 0,
     highBilling: 0,
     lowBilling: 0,
+    highPercentage: 0,
+    lowPercentage: 0,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- display both high and low markup percentages
- track high and low markup values in initial billing state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b7d36997c8329ab2836c0bbe14091